### PR TITLE
Add getProjectId to utils

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -176,6 +176,55 @@ function getProjectNumber(headers, callback) {
 }
 
 /**
+ * Attempts to retreive the project id for the current active project from the
+ * metadata service. The GCLOUD_PROJECT env variable or another identifying
+ * project name/id must be set so that the underlying request library can
+ * successfully query the metadata service.
+ * {@link https://cloud.google.com/compute/docs/storing-retrieving-metadata}
+ * @param {Object} [headers] - An optional set of headers to include in the http
+ *  request. This function may mutate the given headers object.
+ * @param {getProjectIdCallback} callback - A callback to receive the
+ *  response body (project id) or error encountered during the request.
+ */
+function getProjectId(headers, callback) {
+  if (typeof headers === 'function') {
+    callback = headers;
+    headers = {};
+  }
+  getMetadataValue(METADATA_URL + '/project/project-id', headers,
+    function (err, response, projectId) {
+      if (!err && response.statusCode === 200) {
+        return callback(null, projectId);
+      } else if (err && err.code === 'ENOTFOUND') {
+        return callback(new Error('Could not auto-discover project-id.' +
+          'Please export GCLOUD_PROJECT with your project name'), null);
+      }
+      return callback(err || new Error('Error discovering project id'), null);
+  });
+}
+
+/**
+ * Callback for getProjectId function. This callback will be invoked once
+ * negotiation with the project-id metadata endpoint either succeeds or fails.
+ * Always calls back with two parameters, one of which will always be null.
+ * @callback getProjectIdCallback
+ * @param {Error|Null} - If an error is encountered during the request this
+ *  param will be an instance of the Error class otherwise it will be null.
+ * @param {String|Null} - If no error is encountered during the request then
+ *  this param will be of type string and its value will be the related project
+ *  id; otherwise it will be null.
+ * @example
+ * function myCallback (err, projectId) {
+ *  if (err) {
+ *    console.error('Encountered error fetching project id', err);
+ *    return;
+ *  }
+ *  console.log('Got project id', projectId);
+ * }
+ * utils.getProjectId(myCallback);
+ */
+
+/**
  * Attempts to retrieve the GCE instance hostname for the current active project
  * from the metadata service (See https://cloud.google.com/compute/docs/metadata).
  *
@@ -217,6 +266,7 @@ function getInstanceId(headers, callback) {
 
 module.exports = {
   getProjectNumber: getProjectNumber,
+  getProjectId: getProjectId,
   getHostname: getHostname,
   getInstanceId: getInstanceId,
   authorizedRequestFactory: authorizedRequestFactory,


### PR DESCRIPTION
Add the getProjectId function to the common diagnostics which allows
for querying of the metadata service for the running instances project
id. This function has the same invocation and callback signature as
getProjectNumber.