### PR TITLE
Add Istanbul and Coveralls to shared diagnostics

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,3 +8,6 @@ node_js:
 
 env:
   - GCLOUD_PROJECT=0
+
+script:
+  - npm run-script coveralls

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Google Cloud Diagnostics Common
 
+[![Coverage Status](https://coveralls.io/repos/github/GoogleCloudPlatform/cloud-diagnostics-common-nodejs/badge.svg?branch=master)](https://coveralls.io/github/GoogleCloudPlatform/cloud-diagnostics-common-nodejs?branch=master)
+
 This module implements utility and logging functionality used by the cloud
 Tracing and Debugging agents for Node.js. This module is
 under development and is not suitable for production

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "main": "index.js",
   "repository": "GoogleCloudPlatform/cloud-diagnostics-common-nodejs",
   "scripts": {
-    "test": "mocha test"
+    "test": "mocha test",
+    "coveralls": "istanbul cover ./node_modules/mocha/bin/_mocha --report lcovonly -- -R spec && cat ./coverage/lcov.info | ./node_modules/coveralls/bin/coveralls.js && rm -rf ./coverage"
   },
   "keywords": [
     "google",
@@ -25,8 +26,11 @@
   ],
   "license": "Apache-2.0",
   "devDependencies": {
+    "coveralls": "^2.11.11",
+    "istanbul": "^0.4.4",
     "jshint": "^2.8.0",
     "mocha": "^2.2.5",
+    "mocha-lcov-reporter": "^1.2.0",
     "nock": "^2.10.0",
     "proxyquire": "^1.7.4"
   },


### PR DESCRIPTION
Add Istanbul, mocha-lcov-reporter and Coveralls to development
dependencies. Add `coveralls` npm script (`npm run-script coveralls`)
to package.json for CI runs. Invoke this script in `.travis.yml` over
default `npm test` through `script` directive. Add coverage badge to
`README.md`.