### PR TITLE
Increase test coverage >95%

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules
 npm-debug.log
+coverage

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,5 +9,9 @@ node_js:
 env:
   - GCLOUD_PROJECT=0
 
+before_script:
+  - export GOOGLE_APPLICATION_CREDENTIALS=$(pwd)/test/fixtures/stub_cert.json
+  - echo $GOOGLE_APPLICATION_CREDENTIALS
+
 script:
   - npm run-script coveralls

--- a/lib/logger.js
+++ b/lib/logger.js
@@ -68,7 +68,7 @@ module.exports = {
       }
       args.unshift(module.exports.LEVEL_NAMES[level] + ':' + prefix_ + ':');
       console.log.apply(console, args);
-      if (logFd) {
+      if (logFd && (localLogCount < localLimit_)) {
         localLogCount++;
         fs.write(logFd, args.join(' ') + '\n');
       }

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "repository": "GoogleCloudPlatform/cloud-diagnostics-common-nodejs",
   "scripts": {
     "test": "mocha test",
+    "coverage": "istanbul cover ./node_modules/mocha/bin/_mocha test",
     "coveralls": "istanbul cover ./node_modules/mocha/bin/_mocha --report lcovonly -- -R spec && cat ./coverage/lcov.info | ./node_modules/coveralls/bin/coveralls.js && rm -rf ./coverage"
   },
   "keywords": [
@@ -31,6 +32,7 @@
     "jshint": "^2.8.0",
     "mocha": "^2.2.5",
     "mocha-lcov-reporter": "^1.2.0",
+    "mock-fs": "^3.11.0",
     "nock": "^2.10.0",
     "proxyquire": "^1.7.4"
   },

--- a/test/fixtures/stub_cert.json
+++ b/test/fixtures/stub_cert.json
@@ -1,0 +1,12 @@
+{
+  "type": "service_account",
+  "project_id": "stub",
+  "private_key_id": "sodfjosdjfosjdi1",
+  "private_key": "-----BEGIN RSA PRIVATE KEY-----\nMIICXQIBAAKBgQCcGvNwt33XiYQnZ7cxzKGO5HlXQTNqbMvfQA7I0OsVUe/IJ/+1\nyIM6x0gt5Aj+OXwfWWGObTWRTs/085yxvGqjQtqO+ter5skgpXK9BiyPVH0IoTNm\n5iq2AJOwIg0dO71ZVP+87lV8gYu33y9+ATGQpytdGOLzU6azc7b/DjNq2wIDAQAB\nAoGAG3J1qTTqEHKiZNdMk5n6Mgij+R6CrsywT/GQZ+ir3NTKRzQZNtopkLUnUMJO\nfnyXAWAS0hsLlx/3WodW3r1VNlUGeL6QaXUrIePusKfOaeEqm0WmHb4Pg+UDVshT\nqSnDaASF/0QiZenta6nW9ryS6aX3D9CnknrDWrwkFGiW/5kCQQD/iJmXxDnVj0as\nOoVoLeR4PJ8TnJND7k5114lZt3fgI5N1DZlntPN+8D3webRjDSEv+u1qDl9cjPOJ\nN2ny4n4tAkEAnGPkb2FhXq58h50zOsCft4+8ytp9QJbIK/RXZkiYEB5o8esq4GlC\ndzx3N127JJTvPCqkhRlsequF2nwD/ww6JwJBALMVnt8YLJgZA6SsltZ+Y0JI6guq\njiLrnp1D4wS3ahHxnORKFZry3Du4TxB7mwpYJ0wjBcRwMjEAr6UY6u3IAjkCQGht\nJ07cNnlTh6HCbT/Q+ZVHrGfDpxkm1bjL6kRJOwigVbEcN8AraQ9XV7+nndvaeziw\nvLSHenEa8UEnyD9Y+ccCQQDZ//jp0uJpz66KIu7VFtUO2VWeIvGPHVLsFVJBAiGK\noV76eU64wXxo43vCZGNBtMMiEXnOT2FztgjLfN+A5Beq\n-----END RSA PRIVATE KEY-----",
+  "client_email": "sfsdfdf@developer.gserviceaccount.com",
+  "client_id": "ghjghjghjghj",
+  "auth_uri": "https://accounts.google.com/o/oauth2/auth",
+  "token_uri": "https://accounts.google.com/o/oauth2/token",
+  "auth_provider_x509_cert_url": "https://www.googleapis.com/oauth2/v1/certs",
+  "client_x509_cert_url": "https://www.googleapis.com/robot/v1/metadata"
+}

--- a/test/test-authorizedRequestFactory.js
+++ b/test/test-authorizedRequestFactory.js
@@ -1,0 +1,95 @@
+/**
+ * Copyright 2016 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+'use strict';
+var proxyquire = require('proxyquire').noPreserveCache();
+var nock = require('nock');
+var assert = require('assert');
+
+nock.disableNetConnect();
+describe('utils.authorizedRequestFactory', function() {
+  var authMock;
+  after(function() {
+    nock.cleanAll();
+    nock.enableNetConnect();
+  });
+  beforeEach(function () {
+    authMock = nock('https://accounts.google.com:443')
+    .post('/o/oauth2/token')
+    .reply(200, {
+      access_token: 'stub_token',
+      token_type: 'Bearer',
+      expires_in: 3600
+    });
+  });
+  afterEach(function () {
+    nock.cleanAll();
+  });
+ 
+   describe('authorizedRequestFactory', function() {
+    it('should return an error on broken configuration', function (done) {
+      var oldEnv = process.env.GOOGLE_APPLICATION_CREDENTIALS;
+      process.env.GOOGLE_APPLICATION_CREDENTIALS = './not-a-file.json';
+      var utils = require('../lib/utils.js');
+      var req = utils.authorizedRequestFactory(['https://www.googleapis.com/auth/cloud-platform']);
+      req({'X-custom-header': 'true', url: 'http://www.test.com/test'}, 
+        function (err, response, body) {
+          assert.ok(err instanceof Error, 'Should be an error');
+          process.env.GOOGLE_APPLICATION_CREDENTIALS = oldEnv;
+          done();
+        }
+      );
+    });
+    it('should return a function', function() {
+      var utils = require('../lib/utils.js');
+      var result = utils.authorizedRequestFactory(['https://www.googleapis.com/auth/cloud-platform']);
+      assert(typeof result === 'function');
+    });
+    it('should be able to make a valid request with options', function (done) {
+      var utils = require('../lib/utils.js');
+      var req = utils.authorizedRequestFactory(['https://www.googleapis.com/auth/cloud-platform']);
+      var mock = nock('http://www.test.com')
+        .get('/test')
+        .once()
+        .reply(200, 'test');
+      req({'X-custom-header': 'true', url: 'http://www.test.com/test'}, 
+        function (err, response, body) {
+          assert.deepEqual(err, null, 'error should be null');
+          assert.ok(typeof response === 'object');
+          assert.deepEqual(body, 'test');
+          mock.done();
+          done();
+        }
+      );
+    });
+    it('should be able to make a valid request with no options', function (done) {
+      var utils = require('../lib/utils.js');
+      var req = utils.authorizedRequestFactory(['https://www.googleapis.com/auth/cloud-platform']);
+      var mock = nock('http://www.test.com')
+        .get('/test')
+        .once()
+        .reply(200, 'test');
+      req('http://www.test.com/test', 
+        function (err, response, body) {
+          assert.deepEqual(err, null, 'error should be null');
+          assert.ok(typeof response === 'object');
+          assert.deepEqual(body, 'test');
+          mock.done();
+          done();
+        }
+      );
+    });
+  });
+});

--- a/test/test-logger.js
+++ b/test/test-logger.js
@@ -15,9 +15,15 @@
  */
 
 'use strict';
-
+var os = require('os');
+var fs = require('fs');
+var fsMock = require('mock-fs');
+var proxyquire = require('proxyquire').noPreserveCache();
 var assert = require('assert');
-var logger = require('../lib/logger.js');
+var PREFIX = 'mock_fd_logger';
+var moment = require('moment');
+var MOCK_FILE = [PREFIX, 'log.txt'].join('_');
+var MOCK_PATH = os.tmpdir()+'/'+MOCK_FILE; // mock-fs always uses forward slashes
 
 /* Stub console.log for testing */
 var buffer = [];
@@ -27,8 +33,223 @@ console._stdout.write = function() {
   orig.apply(this, arguments);
 };
 
+describe('mocking fd logger with config', function () {
+  it('should write an entry to the fs mock when log is called', function () {
+    var logger = require('../lib/logger.js');
+    var l = logger.create(logger.SILLY, PREFIX, 9);
+    for (var i = 0; i < 15; i += 1) {
+      l.info('info_');
+    }
+    var s = fs.readFileSync(MOCK_PATH).toString();
+    assert.deepEqual(s.split('\n').length, 10, 'There should be 10 entries in the logs')
+  });
+  before(function () {
+    var mockTree = {};
+    mockTree[os.tmpdir()] = {};
+    mockTree[os.tmpdir()][MOCK_FILE] = '';
+    fsMock(mockTree, {createTmp: false});
+  });
+  after(function () {
+    fsMock.restore();
+  });
+});
 
-describe('logger', function() {
+describe('mocking fd logger without config', function () {
+  it('should not write an entry to the fs mock when log is called', function () {
+    var logger = require('../lib/logger.js');
+    var l = logger.create();
+    for (var i = 0; i < 5; i += 1) {
+      l.info('info_');
+    }
+    var s = fs.readFileSync(os.tmpdir()+'/_log.txt').toString();
+    assert.deepEqual(s, '', 'The log file should be empty');
+  });
+  before(function () {
+    var mockTree = {};
+    mockTree[os.tmpdir()] = {};
+    mockTree[os.tmpdir()]['_log.txt'] = '';
+    fsMock(mockTree, {createTmp: false});
+  });
+  after(function () {
+    fsMock.restore();
+  });
+});
+
+describe('logging a breakpoint object', function () {
+  var checkTime = /createdTime/;
+  var checkCondition = /condition/;
+  var checkExpression = /expressions/;
+  it('should log a breakpoint object correctly', function () {
+    var logger = require('../lib/logger.js');
+    var correctOutput = [
+      'ERROR:mock_fd_logger: breakpoint id: 0,\n\tlocation: { line: 3, path:',
+      ' \'/my/project/root/test/fixtures/a/hello.js\' }\n\tcreatedTime: ',
+      moment.unix(parseInt(1471332053, 10)).calendar(),
+      '\n\tcondition: \'if n == 3 then true else false\'\n\texpressions: ',
+      '[ \'if n == 3 then Math.PI * n else n\' ]\n'
+    ].join('');
+    var bp = {
+      id: 0,
+      location: {
+        line: 3,
+        path: '/my/project/root/test/fixtures/a/hello.js'
+      },
+      createdTime: {seconds: 1471332053},
+      condition: 'if n == 3 then true else false',
+      expressions: ['if n == 3 then Math.PI * n else n']
+    };
+    var l = logger.create(logger.SILLY, PREFIX, 10);
+    l.breakpoint(logger.ERROR, '', bp);
+    var s = fs.readFileSync(MOCK_PATH).toString();
+    assert.deepEqual(s, correctOutput, 'The log break point should be properly formatted');
+  });
+  it('should log a breakpoint without time correctly', function () {
+    var log, writer;
+    var logger = require('../lib/logger.js');
+    var bp = {
+      id: 0,
+      location: {
+        line: 3,
+        path: '/my/project/root/test/fixtures/a/hello.js'
+      },
+      condition: 'if n == 3 then true else false',
+      expressions: ['if n == 3 then Math.PI * n else n']
+    };
+    writer = logger.create(logger.SILLY, PREFIX, 10);
+    writer.breakpoint(logger.ERROR, '', bp);
+    log = fs.readFileSync(MOCK_PATH).toString();
+    assert.ok(!checkTime.test(log));
+    assert.ok(checkCondition.test(log));
+    assert.ok(checkExpression.test(log));
+  });
+  it('should log a breakpoint without condition correctly', function () {
+    var log, writer;
+    var logger = require('../lib/logger.js');
+    var bp = {
+      id: 0,
+      location: {
+        line: 3,
+        path: '/my/project/root/test/fixtures/a/hello.js'
+      },
+      createdTime: {seconds: 1471332053},
+      expressions: ['if n == 3 then Math.PI * n else n']
+    };
+    writer = logger.create(logger.SILLY, PREFIX, 10);
+    writer.breakpoint(logger.ERROR, '', bp);
+    log = fs.readFileSync(MOCK_PATH).toString();
+    assert.ok(checkTime.test(log));
+    assert.ok(!checkCondition.test(log));
+    assert.ok(checkExpression.test(log));
+  });
+  it('should log a breakpoint without expressions correctly', function () {
+    var log, writer;
+    var logger = require('../lib/logger.js');
+    var bp = {
+      id: 0,
+      location: {
+        line: 3,
+        path: '/my/project/root/test/fixtures/a/hello.js'
+      },
+      createdTime: {seconds: 1471332053},
+      condition: 'if n == 3 then true else false'
+    };
+    writer = logger.create(logger.SILLY, PREFIX, 10);
+    writer.breakpoint(logger.ERROR, '', bp);
+    log = fs.readFileSync(MOCK_PATH).toString();
+    assert.ok(checkTime.test(log));
+    assert.ok(checkCondition.test(log));
+    assert.ok(!checkExpression.test(log));
+  });
+  it('should not log a breakpoint if the logging level is set lower', function () {
+    var log, writer;
+    var logger = require('../lib/logger.js');
+    var bp = {
+      id: 0,
+      location: {
+        line: 3,
+        path: '/my/project/root/test/fixtures/a/hello.js'
+      },
+      createdTime: {seconds: 1471332053},
+      condition: 'if n == 3 then true else false'
+    };
+    writer = logger.create(logger.ERROR, PREFIX, 10);
+    writer.breakpoint(logger.DEBUG, '', bp);
+    log = fs.readFileSync(MOCK_PATH).toString();
+    assert.deepEqual('', log, 'The log should be empty');
+  });
+  it('should log an array of break points', function () {
+    var correctOutput = [
+      'ERROR:mock_fd_logger: \nERROR:mock_fd_logger: breakpoint id: 0,',
+      '\n\tlocation: { line: 3, path: \'/my/project/root/test/fixtures/',
+      'a/hello.js\' }\n\tcreatedTime: ',
+      moment.unix(parseInt(1471332053, 10)).calendar(),
+      '\n\tcondition: \'',
+      'if n == 3 then true else false\'\nERROR:mock_fd_logger: breakpoint ',
+      'id: 1,\n\tlocation: { line: 10,\n  path: ',
+      '\'/my/project/root/test/fixtures/a/goodbye.js\' }\n\tcreatedTime: ',
+      moment.unix(parseInt(1471332553, 10)).calendar(),
+      '\n\tcondition: \'if n == 4 then true else false\'\n'
+    ].join('');
+    var log, writer;
+    var logger = require('../lib/logger.js');
+    var bps = [
+      {
+        id: 0,
+        location: {
+          line: 3,
+          path: '/my/project/root/test/fixtures/a/hello.js'
+        },
+        createdTime: {seconds: 1471332053},
+        condition: 'if n == 3 then true else false'
+      },
+      {
+        id: 1,
+        location: {
+          line: 10,
+          path: '/my/project/root/test/fixtures/a/goodbye.js'
+        },
+        createdTime: {seconds: 1471332553},
+        condition: 'if n == 4 then true else false'
+      }
+    ];
+    writer = logger.create(logger.DEBUG, PREFIX, 10);
+    writer.breakpoints(logger.SILLY, '', bps);
+    log = fs.readFileSync(MOCK_PATH).toString();
+    assert.deepEqual('', log, 'The log should be empty');
+    writer.breakpoints(logger.ERROR, '', bps);
+    // cristiancavalli added the \r\n replace with \n since it looks
+    // like utils.inspect is changing behavior in node v6.4.0 and
+    // newlining with \r\n instead of just \n
+    // @TODO figure out if this is intended and why - the rest of the
+    // ouput uses /n and other versions pass without this
+    log = fs.readFileSync(MOCK_PATH).toString().replace(/\r\n/g, '\n');
+    assert.deepEqual(correctOutput, log, 'The log should be properly formatted');
+  });
+  it('should log an interval', function () {
+    var log, writer;
+    var correctOutput = 'ERROR:mock_fd_logger: test 100000.0002ms\n';
+    var logger = require('../lib/logger.js');
+    writer = logger.create(logger.ERROR, PREFIX, 10);
+    writer.interval(logger.DEBUG, 'test', 1000);
+    log = fs.readFileSync(MOCK_PATH).toString();
+    assert.deepEqual('', log, 'The log should be empty');
+    writer.interval(logger.ERROR, 'test', [100, 200]);
+    log = fs.readFileSync(MOCK_PATH).toString();
+    assert.deepEqual(correctOutput, log, 'The log should be properly formatted');
+  });
+  beforeEach(function () {
+    var mockTree = {};
+    mockTree[os.tmpdir()] = {};
+    mockTree[os.tmpdir()][MOCK_FILE] = '';
+    fsMock(mockTree, {createTmp: false});
+  });
+  afterEach(function () {
+    fsMock.restore();
+  });
+});
+
+describe('logger base-functionality', function() {
+  var logger = require('../lib/logger.js');
   it('should return a logger through the create function', function() {
     var l = logger.create(logger.DEBUG, __filename);
     assert.ok(l);
@@ -69,7 +290,4 @@ describe('logger', function() {
     l.debug('d');
     assert.ok(buffer.length === 0);
   });
-
-  it('should correctly log a breakpoint object');
-  it('should correctly log an array of breakpoints');
 });


### PR DESCRIPTION
Increase test coverage to cover current API. Add logic
to `logger.js` to respect given log limits. Add npm
coverage script and add configuration in `.travis.yml` to
export the stub credentials file used for testing client
configuration. Add coverage to `.gitignore` to ignore
generated files from added npm coverage script.

Dependencies Added:
`mock-fs` - Added to mock logging so that log statements can be
  analyzed for formatting correctness.

**Note:**
* Included key in `test/fixtures/stub_cert.json` is a valid key but
not connected to any account.