### PR TITLE
Implemented reading key file/credentials config object for auth client

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -21,8 +21,6 @@ var request = require('request');
 var isFunction = require('lodash.isfunction');
 // we only need a single instance
 var googleAuth = new GoogleAuth();
-var cachedAuthClients = {};
-var cachedConfig;
 
 /** @const {number} */ var MAX_RETRY_ATTEMPTS = 5;
 /** @const {number} */ var MIN_RETRY_TIMEOUT = 1000; // milliseconds
@@ -56,42 +54,24 @@ function retryDelay(attempt) {
  * scopes and configuration, using a cached client if one exists.
  */
 function getAuthClient(scopes, config, callback) {
-  if (!config) {
-    config = {};
-  } else if (isFunction(config)) {
+  if (isFunction(config)) {
     callback = config;
-    config = {};
+    config = null;
   }
 
-  // Make it an error to provide a config that's different than a previous one.
-  // This is so cached clients don't conflict with each other.
-  if (cachedConfig) {
-    if (cachedConfig != config) {
-      callback(new Error('Used more than one config file.'));
-      return;
-    }
-  } else {
-    cachedConfig = config;
-  }
-
-  if (cachedAuthClients[scopes]) {
-    callback(null, cachedAuthClients[scopes]);
-    return;
-  }
-
-  if (config.keyFile) {
+  if (config && config.keyFile) {
     var authClient = new googleAuth.JWT();
     authClient.keyFile = config.keyFile;
     authClient.email = config.email;
     authClient.scopes = scopes;
-    addScopeAndCache(null, authClient);
-  } else if (config.credentials) {
-    googleAuth.fromJSON(config.credentials, addScopeAndCache);
+    addScope(null, authClient);
+  } else if (config && config.credentials) {
+    googleAuth.fromJSON(config.credentials, addScope);
   } else {
-    googleAuth.getApplicationDefault(addScopeAndCache);
+    googleAuth.getApplicationDefault(addScope);
   }
 
-  function addScopeAndCache(err, authClient) {
+  function addScope(err, authClient) {
     if (err) {
       callback(err);
       return;
@@ -99,7 +79,6 @@ function getAuthClient(scopes, config, callback) {
     if (authClient.createScopedRequired && authClient.createScopedRequired()) {
       authClient = authClient.createScoped(scopes);
     }
-    cachedAuthClients[scopes] = authClient;
     callback(null, authClient);
   }
 }

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -64,7 +64,7 @@ function getAuthClient(scopes, config, callback) {
     authClient.keyFile = config.keyFile;
     authClient.email = config.email;
     authClient.scopes = scopes;
-    addScope(null, authClient);
+    callback(null, authClient);
   } else if (config && config.credentials) {
     googleAuth.fromJSON(config.credentials, addScope);
   } else {
@@ -81,14 +81,6 @@ function getAuthClient(scopes, config, callback) {
     }
     callback(null, authClient);
   }
-}
-
-/**
- * Returns a google auth client for the current application and provided
- * scopes, using a cached client if one exists.
- */
-function getApplicationDefaultAuth(scopes, callback) {
-  getAuthClient(scopes, null, callback);
 }
 
 /**
@@ -128,10 +120,12 @@ function requestWithRetry(request, options, callback) {
  * the details of working with auth in the client code.
  *
  * @param {Array<string>} scopes list of scopes to request as part of auth
+ * @param {Object} config an object with extra configuration parameters (such
+ *     as keyFile or key)
  * @return {function(Object, function(=?,=?,=?):?)} request style function
  *     accepting (options, callback)
  */
-function authorizedRequestFactory(scopes) {
+function authorizedRequestFactory(scopes, config) {
 
   function makeRequest(options, callback) {
     // authClient expects options to be an object rather than a bare url.
@@ -139,7 +133,7 @@ function authorizedRequestFactory(scopes) {
     if (typeof options === 'string') {
       options = {url: options};
     }
-    getApplicationDefaultAuth(scopes, function(err, authClient) {
+    getAuthClient(scopes, config, function(err, authClient) {
       if (err) {
         callback(err);
         return;
@@ -290,5 +284,5 @@ module.exports = {
   getInstanceId: getInstanceId,
   authorizedRequestFactory: authorizedRequestFactory,
   requestWithRetry: requestWithRetry,
-  getApplicationDefaultAuth: getApplicationDefaultAuth,
+  getAuthClient: getAuthClient
 };

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -16,6 +16,7 @@
 
  'use strict';
 
+var fs = require('fs');
 var GoogleAuth = require('google-auth-library');
 var request = require('request');
 var isFunction = require('lodash.isfunction');
@@ -51,7 +52,7 @@ function retryDelay(attempt) {
 
 /**
  * Returns a google auth client for the current application with provided
- * scopes and configuration, using a cached client if one exists.
+ * scopes and configuration .
  */
 function getAuthClient(scopes, config, callback) {
   if (isFunction(config)) {
@@ -60,11 +61,7 @@ function getAuthClient(scopes, config, callback) {
   }
 
   if (config && config.keyFile) {
-    var authClient = new googleAuth.JWT();
-    authClient.keyFile = config.keyFile;
-    authClient.email = config.email;
-    authClient.scopes = scopes;
-    callback(null, authClient);
+    googleAuth.fromStream(fs.createReadStream(config.keyFile), addScope);
   } else if (config && config.credentials) {
     googleAuth.fromJSON(config.credentials, addScope);
   } else {
@@ -126,24 +123,31 @@ function requestWithRetry(request, options, callback) {
  *     accepting (options, callback)
  */
 function authorizedRequestFactory(scopes, config) {
-
+  var authClient;
   function makeRequest(options, callback) {
     // authClient expects options to be an object rather than a bare url.
     // Coerce into an object here
     if (typeof options === 'string') {
       options = {url: options};
     }
-    getAuthClient(scopes, config, function(err, authClient) {
-      if (err) {
-        callback(err);
-        return;
-      }
+    if (authClient) {
       authClient.request(options, function(err, body, response) {
-        // Ugh. google-auth-library changes the argument order for the
-        // callback. Fix that here.
         callback(err, response, body);
       });
-    });
+    } else {
+      getAuthClient(scopes, config, function(err, client) {
+        if (err) {
+          callback(err);
+          return;
+        }
+        authClient = client;
+        authClient.request(options, function(err, body, response) {
+          // Ugh. google-auth-library changes the argument order for the
+          // callback. Fix that here.
+          callback(err, response, body);
+        });
+      });
+    }
   }
 
   return function(options, callback) {

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -124,34 +124,40 @@ function requestWithRetry(request, options, callback) {
  */
 function authorizedRequestFactory(scopes, config) {
   var authClient;
+  var queuedRequests = [];
+  getAuthClient(scopes, config, function(err, client) {
+    if (err) {
+      callback(err);
+      return;
+    }
+    authClient = client;
+    if (queuedRequests.length > 0) {
+      queuedRequests.forEach(function(request) {
+        requestWithRetry(makeRequest, request.options, request.callback);
+      });
+      queuedRequests = [];
+    }
+  });
   function makeRequest(options, callback) {
     // authClient expects options to be an object rather than a bare url.
     // Coerce into an object here
     if (typeof options === 'string') {
       options = {url: options};
     }
-    if (authClient) {
-      authClient.request(options, function(err, body, response) {
-        callback(err, response, body);
-      });
-    } else {
-      getAuthClient(scopes, config, function(err, client) {
-        if (err) {
-          callback(err);
-          return;
-        }
-        authClient = client;
-        authClient.request(options, function(err, body, response) {
-          // Ugh. google-auth-library changes the argument order for the
-          // callback. Fix that here.
-          callback(err, response, body);
-        });
-      });
-    }
+    authClient.request(options, function(err, body, response) {
+      callback(err, response, body);
+    });
   }
 
   return function(options, callback) {
-    requestWithRetry(makeRequest, options, callback);
+    if (authClient) {
+      requestWithRetry(makeRequest, options, callback);
+    } else {
+      queuedRequests.push({
+        options: options,
+        callback: callback
+      });
+    }
   };
 }
 

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -19,7 +19,6 @@
 var fs = require('fs');
 var GoogleAuth = require('google-auth-library');
 var request = require('request');
-var isFunction = require('lodash.isfunction');
 // we only need a single instance
 var googleAuth = new GoogleAuth();
 
@@ -55,7 +54,7 @@ function retryDelay(attempt) {
  * scopes and configuration .
  */
 function getAuthClient(scopes, config, callback) {
-  if (isFunction(config)) {
+  if (typeof(config) === 'function') {
     callback = config;
     config = null;
   }
@@ -123,7 +122,7 @@ function requestWithRetry(request, options, callback) {
  *     accepting (options, callback)
  */
 function authorizedRequestFactory(scopes, config) {
-  // The AuthClient instance associated with each request
+  // The AuthClient instance associated with each instantiation
   var authClient;
   function makeRequest(options, callback) {
     // authClient expects options to be an object rather than a bare url.
@@ -140,10 +139,13 @@ function authorizedRequestFactory(scopes, config) {
     } else {
       getAuthClient(scopes, config, function(err, client) {
         if (err) {
+
           callback(err);
           return;
         }
         if (!authClient) {
+          // google-auth-library changes the argument order for the
+          // callback. Fix that here.
           authClient = client;
         }
         authClient.request(options, function(err, body, response) {

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -123,14 +123,29 @@ function requestWithRetry(request, options, callback) {
  *     accepting (options, callback)
  */
 function authorizedRequestFactory(scopes, config) {
+  // The AuthClient instance associated with each request
   var authClient;
+  // Requests that were made before authClient was initialized
   var queuedRequests = [];
+  // A field that holds the error object that is created if authClient could
+  // not be initialized
+  var clientErr;
+  // Attempt to initialize authClient here.
   getAuthClient(scopes, config, function(err, client) {
     if (err) {
-      callback(err);
+      // Set clientErr so future requests will return the same error
+      clientErr = err;
+      // Empty the request queue
+      if (queuedRequests.length > 0) {
+        queuedRequests.forEach(function(request) {
+          request.callback(err);
+        });
+        queuedRequests = [];
+      }
       return;
     }
     authClient = client;
+    // Empty the request queue
     if (queuedRequests.length > 0) {
       queuedRequests.forEach(function(request) {
         requestWithRetry(makeRequest, request.options, request.callback);
@@ -151,8 +166,18 @@ function authorizedRequestFactory(scopes, config) {
 
   return function(options, callback) {
     if (authClient) {
+      // Main path of execution.
       requestWithRetry(makeRequest, options, callback);
     } else {
+      // This path is taken if authClient wasn't initialized yet.
+      // This could be if there was a failure in doing so, in which case
+      // the provided callback is called instantly with an error.
+      // Otherwise, authClient simply hasn't been initialized yet, in which
+      // case the request is queued for future fulfillment when it is.
+      if (clientErr) {
+        callback(clientErr);
+        return;
+      }
       queuedRequests.push({
         options: options,
         callback: callback

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -125,61 +125,36 @@ function requestWithRetry(request, options, callback) {
 function authorizedRequestFactory(scopes, config) {
   // The AuthClient instance associated with each request
   var authClient;
-  // A chain of requests that were made before authClient was initialized
-  var next = function() {};
-  // A field that holds the error object that is created if authClient could
-  // not be initialized
-  var clientErr;
-
-  // Attempt to initialize authClient here.
-  getAuthClient(scopes, config, function(err, client) {
-    if (err) {
-      // Set clientErr so future requests will return the same error
-      clientErr = err;
-    } else {
-      authClient = client;
-    }
-    next(err);
-    next = null;
-  });
-
   function makeRequest(options, callback) {
     // authClient expects options to be an object rather than a bare url.
     // Coerce into an object here
     if (typeof options === 'string') {
       options = {url: options};
     }
-    authClient.request(options, function(err, body, response) {
-      callback(err, response, body);
-    });
+    if (authClient) {
+      authClient.request(options, function(err, body, response) {
+        // Ugh. google-auth-library changes the argument order for the
+        // callback. Fix that here.
+        callback(err, response, body);
+      });
+    } else {
+      getAuthClient(scopes, config, function(err, client) {
+        if (err) {
+          callback(err);
+          return;
+        }
+        if (!authClient) {
+          authClient = client;
+        }
+        authClient.request(options, function(err, body, response) {
+          callback(err, response, body);
+        });
+      });
+    }
   }
 
   return function(options, callback) {
-    if (authClient) {
-      // Main path of execution.
-      requestWithRetry(makeRequest, options, callback);
-    } else {
-      // This path is taken if authClient wasn't initialized yet.
-      // This could be if there was a failure in doing so, in which case
-      // the provided callback is called instantly with an error.
-      // Otherwise, authClient simply hasn't been initialized yet, in which
-      // case the request is delayed for future fulfillment when it is.
-      if (clientErr) {
-        callback(clientErr);
-        return;
-      }
-      var prev = next;
-      next = function(err) {
-        process.nextTick(function() {
-          prev(err);
-          if (err) {
-            callback(err);
-          } else {
-            requestWithRetry(makeRequest, options, callback);
-          }
-        });
-      };
-    }
+    requestWithRetry(makeRequest, options, callback);
   };
 }
 

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -125,34 +125,24 @@ function requestWithRetry(request, options, callback) {
 function authorizedRequestFactory(scopes, config) {
   // The AuthClient instance associated with each request
   var authClient;
-  // Requests that were made before authClient was initialized
-  var queuedRequests = [];
+  // A chain of requests that were made before authClient was initialized
+  var next = function() {};
   // A field that holds the error object that is created if authClient could
   // not be initialized
   var clientErr;
+
   // Attempt to initialize authClient here.
   getAuthClient(scopes, config, function(err, client) {
     if (err) {
       // Set clientErr so future requests will return the same error
       clientErr = err;
-      // Empty the request queue
-      if (queuedRequests.length > 0) {
-        queuedRequests.forEach(function(request) {
-          request.callback(err);
-        });
-        queuedRequests = [];
-      }
-      return;
+    } else {
+      authClient = client;
     }
-    authClient = client;
-    // Empty the request queue
-    if (queuedRequests.length > 0) {
-      queuedRequests.forEach(function(request) {
-        requestWithRetry(makeRequest, request.options, request.callback);
-      });
-      queuedRequests = [];
-    }
+    next(err);
+    next = null;
   });
+
   function makeRequest(options, callback) {
     // authClient expects options to be an object rather than a bare url.
     // Coerce into an object here
@@ -173,15 +163,22 @@ function authorizedRequestFactory(scopes, config) {
       // This could be if there was a failure in doing so, in which case
       // the provided callback is called instantly with an error.
       // Otherwise, authClient simply hasn't been initialized yet, in which
-      // case the request is queued for future fulfillment when it is.
+      // case the request is delayed for future fulfillment when it is.
       if (clientErr) {
         callback(clientErr);
         return;
       }
-      queuedRequests.push({
-        options: options,
-        callback: callback
-      });
+      var prev = next;
+      next = function(err) {
+        process.nextTick(function() {
+          prev(err);
+          if (err) {
+            callback(err);
+          } else {
+            requestWithRetry(makeRequest, options, callback);
+          }
+        });
+      };
     }
   };
 }

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -18,9 +18,11 @@
 
 var GoogleAuth = require('google-auth-library');
 var request = require('request');
+var isFunction = require('lodash.isfunction');
 // we only need a single instance
 var googleAuth = new GoogleAuth();
 var cachedAuthClients = {};
+var cachedConfig;
 
 /** @const {number} */ var MAX_RETRY_ATTEMPTS = 5;
 /** @const {number} */ var MIN_RETRY_TIMEOUT = 1000; // milliseconds
@@ -50,26 +52,64 @@ function retryDelay(attempt) {
 }
 
 /**
- * Returns a google auth client for the current application and provided
- * scopes using a cached client if one exists.
+ * Returns a google auth client for the current application with provided
+ * scopes and configuration, using a cached client if one exists.
  */
-function getApplicationDefaultAuth(scopes, callback) {
-  scopes.sort();
+function getAuthClient(scopes, config, callback) {
+  if (!config) {
+    config = {};
+  } else if (isFunction(config)) {
+    callback = config;
+    config = {};
+  }
+
+  // Make it an error to provide a config that's different than a previous one.
+  // This is so cached clients don't conflict with each other.
+  if (cachedConfig) {
+    if (cachedConfig != config) {
+      callback(new Error('Used more than one config file.'));
+      return;
+    }
+  } else {
+    cachedConfig = config;
+  }
+
   if (cachedAuthClients[scopes]) {
     callback(null, cachedAuthClients[scopes]);
-  } else {
-    googleAuth.getApplicationDefault(function(err, authClient) {
-      if (err) {
-        callback(err);
-        return;
-      }
-      if (authClient.createScopedRequired && authClient.createScopedRequired()) {
-        authClient = authClient.createScoped(scopes);
-      }
-      cachedAuthClients[scopes] = authClient;
-      callback(null, authClient);
-    });
+    return;
   }
+
+  if (config.keyFile) {
+    var authClient = new googleAuth.JWT();
+    authClient.keyFile = config.keyFile;
+    authClient.email = config.email;
+    authClient.scopes = scopes;
+    addScopeAndCache(null, authClient);
+  } else if (config.credentials) {
+    googleAuth.fromJSON(config.credentials, addScopeAndCache);
+  } else {
+    googleAuth.getApplicationDefault(addScopeAndCache);
+  }
+
+  function addScopeAndCache(err, authClient) {
+    if (err) {
+      callback(err);
+      return;
+    }
+    if (authClient.createScopedRequired && authClient.createScopedRequired()) {
+      authClient = authClient.createScoped(scopes);
+    }
+    cachedAuthClients[scopes] = authClient;
+    callback(null, authClient);
+  }
+}
+
+/**
+ * Returns a google auth client for the current application and provided
+ * scopes, using a cached client if one exists.
+ */
+function getApplicationDefaultAuth(scopes, callback) {
+  getAuthClient(scopes, null, callback);
 }
 
 /**

--- a/package.json
+++ b/package.json
@@ -40,7 +40,6 @@
   "dependencies": {
     "google-auth-library": "git://github.com/google/google-auth-library-nodejs.git#02f587472ecdc2582f8d5fc754996aa6ef9388a0",
     "moment": "^2.15.0",
-    "request": "^2.75.0",
-    "lodash.isfunction": "^3.0.8"
+    "request": "^2.75.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -34,7 +34,8 @@
     "mocha-lcov-reporter": "^1.2.0",
     "mock-fs": "^3.11.0",
     "nock": "^8.0.0",
-    "proxyquire": "^1.7.4"
+    "proxyquire": "^1.7.4",
+    "shimmer": "^1.1.0"
   },
   "dependencies": {
     "google-auth-library": "git://github.com/google/google-auth-library-nodejs.git#02f587472ecdc2582f8d5fc754996aa6ef9388a0",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
   "dependencies": {
     "google-auth-library": "git://github.com/google/google-auth-library-nodejs.git#02f587472ecdc2582f8d5fc754996aa6ef9388a0",
     "moment": "^2.15.0",
-    "request": "^2.75.0,
+    "request": "^2.75.0",
     "lodash.isfunction": "^3.0.8"
   }
 }

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
   "dependencies": {
     "google-auth-library": "git://github.com/google/google-auth-library-nodejs.git#02f587472ecdc2582f8d5fc754996aa6ef9388a0",
     "moment": "^2.15.0",
-    "request": "^2.75.0"
+    "request": "^2.75.0,
+    "lodash.isfunction": "^3.0.8"
   }
 }

--- a/test/test-authorizedRequestFactory.js
+++ b/test/test-authorizedRequestFactory.js
@@ -91,5 +91,26 @@ describe('utils.authorizedRequestFactory', function() {
         }
       );
     });
+    it('should take config input without throwing', function (done) {
+      var utils = require('../lib/utils.js');
+      var config = {
+        key: require('./fixtures/stub_cert.json')
+      };
+      var req = utils.authorizedRequestFactory(['https://www.googleapis.com/auth/cloud-platform'],
+        config);
+      var mock = nock('http://www.test.com')
+        .get('/test')
+        .once()
+        .reply(200, 'test');
+      req('http://www.test.com/test',
+        function (err, response, body) {
+          assert.deepEqual(err, null, 'error should be null');
+          assert.ok(typeof response === 'object');
+          assert.deepEqual(body, 'test');
+          mock.done();
+          done();
+        }
+      );
+    });
   });
 });

--- a/test/test-utils.js
+++ b/test/test-utils.js
@@ -20,9 +20,14 @@ var assert = require('assert');
 
 
 function GoogleAuth() {}
-  GoogleAuth.prototype.getApplicationDefault = function(cb) {
+GoogleAuth.prototype.getApplicationDefault = function(cb) {
   return cb(null, 'Awesome Auth Client');
 };
+GoogleAuth.prototype.fromJSON = function(json, cb) {
+  return cb(null, json);
+};
+GoogleAuth.JWT = function() {};
+
 var utils = proxyquire('../lib/utils.js', {
   'google-auth-library': GoogleAuth
 });
@@ -165,27 +170,34 @@ describe('utils', function() {
     });
   });
 
-  describe('getApplicationDefaultAuth', function() {
+  describe('getAuthClient', function() {
     it('should work with empty scopes', function(done) {
-      utils.getApplicationDefaultAuth([], function(err, client) {
+      utils.getAuthClient([], function(err, client) {
         assert(!err);
         assert(client);
         done();
       });
     });
-
-    it('should work with out of order scopes', function(done) {
-      var scopes1 = ['https://www.googleapis.com/auth/trace.append',
-                     'https://www.googleapis.com/auth/trace.readonly'];
-      var scopes2 = ['https://www.googleapis.com/auth/trace.readonly',
-                     'https://www.googleapis.com/auth/trace.append'];
-      utils.getApplicationDefaultAuth(scopes1, function(err, client1) {
+    it('should use JSON credentials when provided', function(done) {
+      var config = {
+        credentials: require('./fixtures/stub_cert.json')
+      };
+      utils.getAuthClient([], config, function(err, client) {
         assert(!err);
-        utils.getApplicationDefaultAuth(scopes2, function(err, client2) {
-          assert(!err);
-          assert.equal(client1, client2);
-          done();
-        });
+        assert(client);
+        assert.equal(client, config.credentials);
+        done();
+      });
+    });
+    it('should use a key file when provided', function(done) {
+      var config = {
+        keyFile: './fixtures/stub_cert.json'
+      };
+      utils.getAuthClient([], config, function(err, client) {
+        assert(!err);
+        assert(client);
+        assert.equal(client.keyFile, config.keyFile);
+        done();
       });
     });
   });

--- a/test/test-utils.js
+++ b/test/test-utils.js
@@ -35,7 +35,6 @@ GoogleAuth.prototype.fromStream = function(stream, cb) {
     return cb(null, JSON.parse(contents));
   });
 };
-GoogleAuth.JWT = function() {};
 
 var utils = proxyquire('../lib/utils.js', {
   'google-auth-library': GoogleAuth


### PR DESCRIPTION
Major changes:
* getApplicationDefaultAuth has been changed to getAuthClient, which optionally takes in a config object (but has an otherwise similar signature). It can read either the keyFile or credentials field from that object.
* Global caching of auth client objects has been removed, as it would be more difficult to cache based on a key of { scope list, key file/credentials }. Instead, each call to authorizedRequestFactory() now creates an auth client object in a new closure.
* Tests have been updated. The test that checks for identical clients being returned for out-of-order scopes was removed, because it doesn't apply anymore.

This PR is similar to #27, with the important differences that "caching" has been added back, and the keyFile field is handled differently (using fromStream allows creation of either JWTClient or UserRefreshClient).